### PR TITLE
docker: Improve build speed by piping a TAR stream

### DIFF
--- a/logic/util.go
+++ b/logic/util.go
@@ -8,7 +8,6 @@ import (
 	"github.com/coduno/api/model"
 	"github.com/coduno/api/util"
 	"google.golang.org/appengine/datastore"
-	"google.golang.org/cloud/storage"
 )
 
 type InsDel struct {
@@ -85,5 +84,5 @@ func getTaskIndex(c model.Challenge, task *datastore.Key) int {
 }
 
 func readFromGCS(so model.StoredObject) (io.ReadCloser, error) {
-	return storage.NewReader(util.CloudContext(nil), so.Bucket, so.Name)
+	return util.Load(util.CloudContext(nil), so.Bucket, so.Name)
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -28,7 +28,7 @@ func init() {
 	}
 }
 
-func createDockerContainer(image string, binds []string) (*docker.Container, error) {
+func itoc(image string) (*docker.Container, error) {
 	// TODO(victorbalan): Pass the memory limit from test
 	return dc.CreateContainer(docker.CreateContainerOptions{
 		Config: &docker.Config{
@@ -37,7 +37,6 @@ func createDockerContainer(image string, binds []string) (*docker.Container, err
 		HostConfig: &docker.HostConfig{
 			Privileged: false,
 			Memory:     0, // TODO(flowlo): Limit memory
-			Binds:      binds,
 		},
 	})
 }

--- a/runner/simple.go
+++ b/runner/simple.go
@@ -24,7 +24,7 @@ func Simple(ctx context.Context, sub model.KeyedSubmission, ball io.Reader) (tes
 	}
 
 	var c *docker.Container
-	if c, err = createDockerContainer(image, []string{}); err != nil {
+	if c, err = itoc(image); err != nil {
 		return
 	}
 

--- a/test/robot.go
+++ b/test/robot.go
@@ -3,7 +3,7 @@ package test
 import (
 	"encoding/json"
 	"errors"
-	goio "io"
+	"io"
 	"io/ioutil"
 	"path"
 	"strconv"
@@ -21,9 +21,9 @@ func init() {
 	RegisterTester(Robot, robot)
 }
 
-func robot(ctx context.Context, t model.KeyedTest, sub model.KeyedSubmission) (err error) {
+func robot(ctx context.Context, t model.KeyedTest, sub model.KeyedSubmission, ball io.Reader) (err error) {
 	log.Debugf(ctx, "Executing robot tester")
-	var testMap, stdin goio.ReadCloser
+	var testMap, stdin io.ReadCloser
 	if testMap, err = storage.NewReader(util.CloudContext(ctx), util.TemplateBucket, t.Params["tests"]); err != nil {
 		return
 	}

--- a/test/robot.go
+++ b/test/robot.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coduno/api/ws"
 	"golang.org/x/net/context"
 	"google.golang.org/appengine/log"
-	"google.golang.org/cloud/storage"
 )
 
 func init() {
@@ -24,13 +23,16 @@ func init() {
 func robot(ctx context.Context, t model.KeyedTest, sub model.KeyedSubmission, ball io.Reader) (err error) {
 	log.Debugf(ctx, "Executing robot tester")
 	var testMap, stdin io.ReadCloser
-	if testMap, err = storage.NewReader(util.CloudContext(ctx), util.TemplateBucket, t.Params["tests"]); err != nil {
+	if testMap, err = util.Load(util.CloudContext(ctx), util.TemplateBucket, t.Params["tests"]); err != nil {
 		return
 	}
+	defer testMap.Close()
 
-	if stdin, err = storage.NewReader(util.CloudContext(ctx), sub.Code.Bucket, path.Dir(sub.Code.Name)+"/"+util.FileNames["robot"]); err != nil {
+	if stdin, err = util.Load(util.CloudContext(ctx), sub.Code.Bucket, path.Dir(sub.Code.Name)+"/"+util.FileNames["robot"]); err != nil {
 		return
 	}
+	defer stdin.Close()
+
 	var testMapBytes, stdinBytes []byte
 	if stdinBytes, err = ioutil.ReadAll(stdin); err != nil {
 		return
@@ -46,7 +48,7 @@ func robot(ctx context.Context, t model.KeyedTest, sub model.KeyedSubmission, ba
 	}
 	moves, err := testRobot(m, string(stdinBytes))
 	if err != nil {
-		// TODO(victorbalan): Pass the error to the ws so the client knows what he`s doing wrong
+		// TODO(victorbalan): Pass the error to the ws so the client knows what he's doing wrong
 		return
 	}
 	var body []byte

--- a/test/simple.go
+++ b/test/simple.go
@@ -2,25 +2,25 @@ package test
 
 import (
 	"encoding/json"
+	"io"
 
 	"github.com/coduno/api/model"
 	"github.com/coduno/api/runner"
 	"github.com/coduno/api/ws"
 	"golang.org/x/net/context"
-	"google.golang.org/appengine/log"
 )
 
 func init() {
 	RegisterTester(Simple, simple)
 }
 
-func simple(ctx context.Context, t model.KeyedTest, sub model.KeyedSubmission) (err error) {
-	log.Debugf(ctx, "Executing simple tester")
-	var str model.SimpleTestResult
-	if str, err = runner.Simple(ctx, sub); err != nil {
+func simple(ctx context.Context, t model.KeyedTest, sub model.KeyedSubmission, ball io.Reader) (err error) {
+	str, err := runner.Simple(ctx, sub, ball)
+	if err != nil {
 		return
 	}
 
+	// TODO(flowlo): Use a json.Encoder
 	var body []byte
 	if body, err = json.Marshal(str); err != nil {
 		return

--- a/util/storage.go
+++ b/util/storage.go
@@ -1,6 +1,15 @@
 package util
 
-import "google.golang.org/appengine"
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/memcache"
+	"google.golang.org/cloud/storage"
+)
 
 var FileNames = map[string]string{
 	"py":    "app.py",
@@ -23,4 +32,62 @@ func SubmissionBucket() string {
 		return "coduno-dev"
 	}
 	return "coduno"
+}
+
+func Load(ctx context.Context, bucket, name string) (io.ReadCloser, error) {
+	r, err := fromCache(ctx, bucket, name)
+	if err == nil {
+		return r, nil
+	}
+	if err != memcache.ErrCacheMiss {
+		return nil, err
+	}
+	return fromStorage(ctx, bucket, name)
+}
+
+type cachingCloser struct {
+	ctx context.Context
+	key string
+	rc  io.ReadCloser
+	buf *bytes.Buffer
+}
+
+func (c cachingCloser) Read(p []byte) (n int, err error) {
+	return c.Read(p)
+}
+
+func (c cachingCloser) Close() error {
+	go memcache.Set(c.ctx, &memcache.Item{
+		Key:   c.key,
+		Value: c.buf.Bytes(),
+	})
+	return c.rc.Close()
+}
+
+func fromCache(ctx context.Context, bucket, name string) (io.ReadCloser, error) {
+	item, err := memcache.Get(ctx, key(bucket, name))
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.NopCloser(bytes.NewReader(item.Value)), nil
+}
+
+func fromStorage(ctx context.Context, bucket, name string) (io.ReadCloser, error) {
+	rc, err := storage.NewReader(CloudContext(ctx), bucket, name)
+	if err != nil {
+		return nil, err
+	}
+	buf := new(bytes.Buffer)
+	var crc = struct {
+		io.Reader
+		io.Closer
+	}{
+		io.TeeReader(rc, buf),
+		cachingCloser{ctx: ctx, rc: rc, buf: buf, key: key(bucket, name)},
+	}
+	return crc, nil
+}
+
+func key(bucket, name string) string {
+	return "gcs://" + bucket + "/" + name
 }


### PR DESCRIPTION
This significantly improves build time. The full speedup can only be observed with the simple runner as long as reads from GCS are not cached.

On development, uploads to GCS will be silently discarded.